### PR TITLE
Fix for Xcode 15.3 - Set GoogleMobileAds upToNextMajor to 11.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             targets: ["BlueStackOguryAdapterTarget"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", .upToNextMajor(from: "10.10.0")),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", .upToNextMajor(from: "11.0.0")),
         .package(url: "https://github.com/azerion/improvedigital-sdk-ios", .upToNextMajor(from: "3.0.0")),
     ],
     targets: [


### PR DESCRIPTION
Hello,

During the upgrade from Xcode 15.2 to 15.3 of our project, and with BlueStackSDK version 4.4.3, we encounter this message when running the application (It's worth noting that there are no compilation issues):

<img width="1351" alt="Error" src="https://github.com/azerion/BlueStackSDK/assets/637964/264ee0f5-2526-4543-af5f-0f9615e078f9">

**Full error message:**
```
App installation failed: Unable to Install “RF-debug”
Domain: IXUserPresentableErrorDomain
Code: 1
Failure Reason: Please try again later.
Recovery Suggestion: Failed to load Info.plist from bundle at path /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework; Extra info about "/Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist": Couldn't stat /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist: No such file or directory
User Info: {
    DVTErrorCreationDateKey = "2024-03-19 09:50:33 +0000";
    IDERunOperationFailingWorker = IDELaunchiPhoneSimulatorLauncher;
    SimCallingSelector = "installApplication:withOptions:error:";
}
--
App installation failed: Unable to Install “RF-debug”
Domain: IXUserPresentableErrorDomain
Code: 1
Failure Reason: Please try again later.
Recovery Suggestion: Failed to load Info.plist from bundle at path /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework; Extra info about "/Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist": Couldn't stat /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist: No such file or directory
User Info: {
    IDERunOperationFailingWorker = IDELaunchiPhoneSimulatorLauncher;
    SimCallingSelector = "installApplication:withOptions:error:";
}
--
Unable to Install “RF-debug”
Domain: IXUserPresentableErrorDomain
Code: 1
Failure Reason: Please try again later.
Recovery Suggestion: Failed to load Info.plist from bundle at path /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework; Extra info about "/Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist": Couldn't stat /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist: No such file or directory
--
Failed to load Info.plist from bundle at path /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework; Extra info about "/Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist": Couldn't stat /Users/nico/Library/Developer/CoreSimulator/Devices/6BEE0629-73A7-49B7-8A37-FECC7E798BA3/data/Library/Caches/com.apple.mobile.installd.staging/temp.0iVrjA/extracted/Payload/AppRF.app/Frameworks/GoogleMobileAds.framework/Info.plist: No such file or directory
Domain: MIInstallerErrorDomain
Code: 35
User Info: {
    FunctionName = "-[MIBundle _validateWithError:]";
    LegacyErrorString = PackageInspectionFailed;
    SourceFileLine = 64;
}
--

Event Metadata: com.apple.dt.IDERunOperationWorkerFinished : {
    "device_model" = "iPhone16,2";
    "device_osBuild" = "17.4 (21E213)";
    "device_platform" = "com.apple.platform.iphonesimulator";
    "dvt_coredevice_version" = "355.24";
    "dvt_mobiledevice_version" = "1643.100.58";
    "launchSession_schemeCommand" = Run;
    "launchSession_state" = 1;
    "launchSession_targetArch" = arm64;
    "operation_duration_ms" = 8265;
    "operation_errorCode" = 1;
    "operation_errorDomain" = IXUserPresentableErrorDomain;
    "operation_errorWorker" = IDELaunchiPhoneSimulatorLauncher;
    "operation_name" = IDERunOperationWorkerGroup;
    "param_debugger_attachToExtensions" = 0;
    "param_debugger_attachToXPC" = 1;
    "param_debugger_type" = 3;
    "param_destination_isProxy" = 0;
    "param_destination_platform" = "com.apple.platform.iphonesimulator";
    "param_diag_MainThreadChecker_stopOnIssue" = 0;
    "param_diag_MallocStackLogging_enableDuringAttach" = 0;
    "param_diag_MallocStackLogging_enableForXPC" = 1;
    "param_diag_allowLocationSimulation" = 1;
    "param_diag_checker_tpc_enable" = 1;
    "param_diag_gpu_frameCapture_enable" = 0;
    "param_diag_gpu_shaderValidation_enable" = 0;
    "param_diag_gpu_validation_enable" = 0;
    "param_diag_memoryGraphOnResourceException" = 0;
    "param_diag_queueDebugging_enable" = 1;
    "param_diag_runtimeProfile_generate" = 0;
    "param_diag_sanitizer_asan_enable" = 0;
    "param_diag_sanitizer_tsan_enable" = 0;
    "param_diag_sanitizer_tsan_stopOnIssue" = 0;
    "param_diag_sanitizer_ubsan_stopOnIssue" = 0;
    "param_diag_showNonLocalizedStrings" = 0;
    "param_diag_viewDebugging_enabled" = 1;
    "param_diag_viewDebugging_insertDylibOnLaunch" = 1;
    "param_install_style" = 0;
    "param_launcher_UID" = 2;
    "param_launcher_allowDeviceSensorReplayData" = 0;
    "param_launcher_kind" = 0;
    "param_launcher_style" = 0;
    "param_launcher_substyle" = 0;
    "param_runnable_appExtensionHostRunMode" = 0;
    "param_runnable_productType" = "com.apple.product-type.application";
    "param_structuredConsoleMode" = 1;
    "param_testing_launchedForTesting" = 0;
    "param_testing_suppressSimulatorApp" = 0;
    "param_testing_usingCLI" = 0;
    "sdk_canonicalName" = "iphonesimulator17.4";
    "sdk_osVersion" = "17.4";
    "sdk_variant" = iphonesimulator;
}
--


System Information

macOS Version 14.4 (Build 23E214)
Xcode 15.3 (22618) (Build 15E204a)
Timestamp: 2024-03-19T10:50:33+01:00
```

**Here are the libraries we are using:**

<img width="308" alt="Librairies" src="https://github.com/azerion/BlueStackSDK/assets/637964/0928d71a-e44b-41d1-a069-197738e280a6">


**The changes in this pull request address the runtime issue.**